### PR TITLE
fix: determine full path for install folder

### DIFF
--- a/template/normal.sh
+++ b/template/normal.sh
@@ -636,7 +636,7 @@ lookup_script_data() {
   debug "$info_icon Script path: $script_install_path"
   script_install_path=$(recursive_readlink "$script_install_path")
   debug "$info_icon Actual path: $script_install_path"
-  readonly script_install_folder="$(dirname "$script_install_path")"
+  readonly script_install_folder="$( cd -P "$( dirname "$script_install_path" )" && pwd )"
   if [[ -f "$script_install_path" ]]; then
     script_hash=$(hash <"$script_install_path" 8)
     script_lines=$(awk <"$script_install_path" 'END {print NR}')


### PR DESCRIPTION
@pforret  -- I believe this will help.  It sets `script_install_folder` to the absolute path rather than relative path.

Before:
```
❯ ./test.sh action1
script_install_folder=.
```
After
```
❯ ./test.sh action1
script_install_folder=/home/mcrowe
 ```