### PR TITLE
Prevent temp_files[@]: unbound variable error

### DIFF
--- a/template/script.sh
+++ b/template/script.sh
@@ -359,7 +359,7 @@ trap "IO:die \"ERROR \$? after \$SECONDS seconds \n\
 # cf https://askubuntu.com/questions/513932/what-is-the-bash-command-variable-good-for
 
 Script:exit() {
-  for temp_file in "${temp_files[@]}" ; do
+  for temp_file in "${temp_files[@]-}" ; do
     [[ -f "$temp_file" ]] && (
       IO:debug "Delete temp file [$temp_file]"
       rm -f "$temp_file"


### PR DESCRIPTION
Bash offers parameter expansion for unset variables, e.g.: ${varname-}. The bash manual - search for "Parameter expansion" - says the dash (-) has the following effect:

"If parameter is unset, substitute with empty value."
Using the dash (-) in ${temp_files[@]-} prevents the "unbound variable" error:

https://fvue.nl/wiki/Bash:_Error_%60Unbound_variable%27_when_appending_to_empty_array